### PR TITLE
Fixes

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -405,10 +405,15 @@
     "                    ):\n",
     "    '''checks a local copy of kaggle dataset for library version number'''\n",
     "    wheel_lib_name = lib.replace('-','_')\n",
-    "    lib_whl = (lib_path/f\"library-{lib}\").ls().filter(lambda x: wheel_lib_name in x.name.lower())\n",
+    "    local_path = (lib_path/f\"library-{lib}\")\n",
+    "    lib_whl = local_path.ls().filter(lambda x: wheel_lib_name in x.name.lower())\n",
     "    if 1==len(lib_whl):\n",
     "        return re.search(f\"(?<={wheel_lib_name}-)[\\d+.]+\\d\",lib_whl[0].name.lower())[0]\n",
-    "    else: return \"No Version Found\""
+    "    elif 0<len(local_path.ls().filter(lambda x: 'dist' in x.name)):\n",
+    "        lib_whl = (local_path/'dist').ls().filter(lambda x: wheel_lib_name in x.name.lower())\n",
+    "        if 1==len(lib_whl):\n",
+    "            return re.search(f\"(?<={wheel_lib_name}-)[\\d+.]+\\d\",lib_whl[0].name.lower())[0]\n",
+    "    return None"
    ]
   },
   {
@@ -454,10 +459,8 @@
     "                if item.is_dir(): shutil.rmtree(item)\n",
     "                else: item.unlink()\n",
     "        get_pip_library(local_path,lib)\n",
-    "        \n",
     "        ver_local_new = get_local_ds_ver(lib_path,lib)\n",
-    "\n",
-    "        if ver_local_new != ver_local_orig: \n",
+    "        if (ver_local_new != ver_local_orig) or (ver_local_new==None and ver_local_orig==None): \n",
     "            print(f\"{lib} | Updating {lib} in Kaggle from {ver_local_orig} to {ver_local_new}\")\n",
     "            push_dataset(local_path,ver_local_new)\n",
     "        else: print(f\"{lib} | Kaggle dataset already up to date {ver_local_orig} to {ver_local_new}\")\n",

--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -395,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -543,18 +543,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -404,22 +404,11 @@
     "                     lib # Name of library (ie \"fastcore\")\n",
     "                    ):\n",
     "    '''checks a local copy of kaggle dataset for library version number'''\n",
-    "    lib_whl = (lib_path/f\"library-{lib}\").ls().filter(lambda x: lib in x.name.lower())\n",
+    "    wheel_lib_name = lib.replace('-','_')\n",
+    "    lib_whl = (lib_path/f\"library-{lib}\").ls().filter(lambda x: wheel_lib_name in x.name.lower())\n",
     "    if 1==len(lib_whl):\n",
-    "        return re.search(f\"(?<={lib}_)[\\d+.]+\",lib_whl[0].name.lower().replace('-','_'))[0]\n",
+    "        return re.search(f\"(?<={wheel_lib_name}-)[\\d+.]+\\d\",lib_whl[0].name.lower())[0]\n",
     "    else: return \"No Version Found\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# dataset_path = Path('./testds452')\n",
-    "# mk_dataset(dataset_path,'mytestd232s',force=True)\n",
-    "# (dataset_path/'testfile.txt').touch()\n",
-    "# push_dataset(dataset_path,'testing')"
    ]
   },
   {
@@ -448,16 +437,16 @@
     "    for lib in libs:\n",
     "        title = f\"library-{lib}\"\n",
     "        local_path = lib_path/title\n",
-    "        print(f\"Processing {lib} as {title} at {local_path}\")\n",
+    "        print(f\"{lib} | Processing as {title} at {local_path}\")\n",
     "        if Path(local_path).exists(): shutil.rmtree(local_path)\n",
     "\n",
-    "        print(f\"-----Downloading or Creating Dataset\")\n",
+    "        print(f\"{lib} | Downloading or Creating Dataset\")\n",
     "        try: get_dataset(local_path,f\"{username}/{title}\",force=True)\n",
     "        except Exception as ex:\n",
     "            if '404' in str(ex): mk_dataset(local_path,title,force=True)\n",
     "            else: raise ex\n",
     "            \n",
-    "        print(f\"-----Checking dataset version against pip\")\n",
+    "        print(f\"{lib} | Checking dataset version against pip\")\n",
     "        ver_local_orig = get_local_ds_ver(lib_path,lib)\n",
     "\n",
     "        for item in local_path.ls():\n",
@@ -469,11 +458,11 @@
     "        ver_local_new = get_local_ds_ver(lib_path,lib)\n",
     "\n",
     "        if ver_local_new != ver_local_orig: \n",
-    "            print(f\"-----Updating {lib} in Kaggle from {ver_local_orig} to {ver_local_new}\")\n",
+    "            print(f\"{lib} | Updating {lib} in Kaggle from {ver_local_orig} to {ver_local_new}\")\n",
     "            push_dataset(local_path,ver_local_new)\n",
-    "        else: print(f\"-----Kaggle dataset already up to date {ver_local_orig} to {ver_local_new}\")\n",
+    "        else: print(f\"{lib} | Kaggle dataset already up to date {ver_local_orig} to {ver_local_new}\")\n",
     "        if clear_after: shutil.rmtree(local_path)\n",
-    "    print('Complete')"
+    "        print(f\"{lib} | Complete\")"
    ]
   },
   {

--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -395,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +462,8 @@
     "        ver_local_new = get_local_ds_ver(lib_path,lib)\n",
     "        if (ver_local_new != ver_local_orig) or (ver_local_new==None and ver_local_orig==None): \n",
     "            print(f\"{lib} | Updating {lib} in Kaggle from {ver_local_orig} to {ver_local_new}\")\n",
-    "            push_dataset(local_path,ver_local_new)\n",
+    "            \n",
+    "            push_dataset(local_path,ifnone (ver_local_new, \"Version Unknown\"))\n",
     "        else: print(f\"{lib} | Kaggle dataset already up to date {ver_local_orig} to {ver_local_new}\")\n",
     "        if clear_after: shutil.rmtree(local_path)\n",
     "        print(f\"{lib} | Complete\")"
@@ -542,6 +543,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/fastkaggle/core.py
+++ b/fastkaggle/core.py
@@ -152,12 +152,13 @@ def get_local_ds_ver(lib_path, # Local path dataset is stored in
                      lib # Name of library (ie "fastcore")
                     ):
     '''checks a local copy of kaggle dataset for library version number'''
-    lib_whl = (lib_path/f"library-{lib}").ls().filter(lambda x: lib in x.name.lower())
+    wheel_lib_name = lib.replace('-','_')
+    lib_whl = (lib_path/f"library-{lib}").ls().filter(lambda x: wheel_lib_name in x.name.lower())
     if 1==len(lib_whl):
-        return re.search(f"(?<={lib}_)[\d+.]+",lib_whl[0].name.lower().replace('-','_'))[0]
+        return re.search(f"(?<={wheel_lib_name}-)[\d+.]+\d",lib_whl[0].name.lower())[0]
     else: return "No Version Found"
 
-# %% ../00_core.ipynb 27
+# %% ../00_core.ipynb 26
 def create_libs_datasets(libs, # library or list of libraries to create datasets for (ie 'fastcore or ['fastcore','fastkaggle']
                          lib_path, # Local path to dl/create dataset
                          username, # You username
@@ -170,16 +171,16 @@ def create_libs_datasets(libs, # library or list of libraries to create datasets
     for lib in libs:
         title = f"library-{lib}"
         local_path = lib_path/title
-        print(f"Processing {lib} as {title} at {local_path}")
+        print(f"{lib} | Processing as {title} at {local_path}")
         if Path(local_path).exists(): shutil.rmtree(local_path)
 
-        print(f"-----Downloading or Creating Dataset")
+        print(f"{lib} | Downloading or Creating Dataset")
         try: get_dataset(local_path,f"{username}/{title}",force=True)
         except Exception as ex:
             if '404' in str(ex): mk_dataset(local_path,title,force=True)
             else: raise ex
             
-        print(f"-----Checking dataset version against pip")
+        print(f"{lib} | Checking dataset version against pip")
         ver_local_orig = get_local_ds_ver(lib_path,lib)
 
         for item in local_path.ls():
@@ -191,13 +192,13 @@ def create_libs_datasets(libs, # library or list of libraries to create datasets
         ver_local_new = get_local_ds_ver(lib_path,lib)
 
         if ver_local_new != ver_local_orig: 
-            print(f"-----Updating {lib} in Kaggle from {ver_local_orig} to {ver_local_new}")
+            print(f"{lib} | Updating {lib} in Kaggle from {ver_local_orig} to {ver_local_new}")
             push_dataset(local_path,ver_local_new)
-        else: print(f"-----Kaggle dataset already up to date {ver_local_orig} to {ver_local_new}")
+        else: print(f"{lib} | Kaggle dataset already up to date {ver_local_orig} to {ver_local_new}")
         if clear_after: shutil.rmtree(local_path)
-    print('Complete')
+        print(f"{lib} | Complete")
 
-# %% ../00_core.ipynb 28
+# %% ../00_core.ipynb 27
 def create_requirements_dataset(req_fpath, # Path to requirements.txt file
                                 lib_path,#Local path to dl/create dataset
                                 title, # Title you want the kaggle dataset named

--- a/fastkaggle/core.py
+++ b/fastkaggle/core.py
@@ -196,7 +196,8 @@ def create_libs_datasets(libs, # library or list of libraries to create datasets
         ver_local_new = get_local_ds_ver(lib_path,lib)
         if (ver_local_new != ver_local_orig) or (ver_local_new==None and ver_local_orig==None): 
             print(f"{lib} | Updating {lib} in Kaggle from {ver_local_orig} to {ver_local_new}")
-            push_dataset(local_path,ver_local_new)
+            
+            push_dataset(local_path,ifnone (ver_local_new, "Version Unknown"))
         else: print(f"{lib} | Kaggle dataset already up to date {ver_local_orig} to {ver_local_new}")
         if clear_after: shutil.rmtree(local_path)
         print(f"{lib} | Complete")


### PR DESCRIPTION
@jph00 

I ran automated updates on ~80 libraries and found some different library formats I needed to support to make them all work.  These changes should cover the vast majority of pip libraries.  T

Changes:
+ Improve `get_local_ds_version` to return `None` if version couldn't be found, and look in `dist` folder if it cannot find a the version in the top level directory
+ Improve `create_libs_datasets`
    + Improve print statements to not assume they will be in order so they are readable if doing sync on multiple libs in parallel
    + If `get_local_ds_version` is unable to detect a version (edge cases) update the dataset rather than skip
    
    
    
FYI: The automation I am doing happens in https://github.com/Isaac-Flath/kaggle-datasets currently and link to my kaggle account, but happy to move it all elsewhere if there's a place that'd be more useful for people.